### PR TITLE
Added type restriction support for the DBpedia Spotlight service.

### DIFF
--- a/fcw-linking/src/main/java/eu/fbk/dkm/pikes/twm/DBpediaSpotlightAnnotate.java
+++ b/fcw-linking/src/main/java/eu/fbk/dkm/pikes/twm/DBpediaSpotlightAnnotate.java
@@ -1,38 +1,31 @@
 package eu.fbk.dkm.pikes.twm;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import org.codehaus.jackson.map.ObjectMapper;
 
-import java.io.File;
 import java.util.*;
-
-/**
- * Created with IntelliJ IDEA.
- * User: alessio
- * Date: 21/07/14
- * Time: 17:15
- * To change this template use File | Settings | File Templates.
- */
 
 public class DBpediaSpotlightAnnotate extends Linking {
 
     private static String LABEL = "dbpedia-annotate";
     private String confidence;
-    public static final String DBPS_ADDRESS = "http://spotlight.sztaki.hu:2222/rest";
-    public static final double DBPS_MIN_CONFIDENCE = 0.33;
+    private String allowedTypes;
+    static final String DBPS_ADDRESS = "http://model.dbpedia-spotlight.org/en";
+    private static final double DBPS_MIN_CONFIDENCE = 0.33;
 
     public DBpediaSpotlightAnnotate(Properties properties) {
         super(properties, properties.getProperty("address", DBPS_ADDRESS) + "/annotate");
         confidence = properties.getProperty("min_confidence", Double.toString(DBPS_MIN_CONFIDENCE));
+        allowedTypes = properties.getProperty("types", null);
     }
 
     public List<LinkingTag> tag(String text) throws Exception {
-
         ArrayList<LinkingTag> ret = new ArrayList<>();
 
         Map<String, String> pars = new HashMap<>();
         pars.put("confidence", confidence);
+        if (allowedTypes != null) {
+            pars.put("types", allowedTypes);
+        }
         pars.put("text", text);
 
         Map<String, Object> userData;
@@ -67,16 +60,14 @@ public class DBpediaSpotlightAnnotate extends Linking {
 
     public static void main(String[] args) {
         Properties properties = new Properties();
-        properties.setProperty("address", "https://knowledgestore2.fbk.eu/dbps/rest/annotate");
-        properties.setProperty("use_proxy", "0");
-        properties.setProperty("proxy_url", "proxy.fbk.eu");
-        properties.setProperty("proxy_port", "3128");
+        properties.setProperty("address", "http://model.dbpedia-spotlight.org/en");
         properties.setProperty("min_confidence", "0.05");
+        properties.setProperty("types", "Drug,Disease,Chemical_compound");
         properties.setProperty("timeout", "2000");
 
         DBpediaSpotlightAnnotate s = new DBpediaSpotlightAnnotate(properties);
         try {
-            String text = Files.toString(new File("/Users/alessio/Desktop/elastic/test-dbps.txt"), Charsets.UTF_8);
+            String text = "My doctor has suggested to take a pill of Aspirin.";
             List<LinkingTag> tags = s.tag(text);
             for (LinkingTag tag : tags) {
                 System.out.println(tag);


### PR DESCRIPTION
Pull request related to the one issued [here](https://github.com/dkmfbk/pikes/pull/8). Due to missing dependencies (I was not able to figure out how to include them due to lack of documentation for the current project), I hadn't the possibility to run tests on the Maven project. Anyway, the code should run fine as in the previous project.

N.B. 
Please add a section in the README which describes how to contribute to this project :)

Best regards,
Alessandro